### PR TITLE
Accept if no resource is found instead of throwing error.

### DIFF
--- a/ruleHandler.js
+++ b/ruleHandler.js
@@ -58,7 +58,8 @@ module.exports = (slsOptions, slsService, serverless, log) => {
   })
 
   // search in resources for Iot rule events
-  Object.keys(slsService.resources.Resources).forEach(key => {
+  const resources = _.get(slsService, 'resources.Resources', {})
+  Object.keys(resources).forEach(key => {
     const ruleConf = _.get(slsService.resources.Resources[key], 'Properties.TopicRulePayload')
 
     if (!ruleConf || ruleConf.RuleDisabled === "true") {


### PR DESCRIPTION
If there is no resource key defined in serverless.yml, the plugin won't work.  Resource can be optional so, this code will gracefully skip if no resource is found.