### PR TITLE
Make seed policy optional.

### DIFF
--- a/util.js
+++ b/util.js
@@ -42,6 +42,7 @@ module.exports.seedShadows = (seedPath, redisClient) => {
 }
 
 module.exports.seedPolicies = (seedPath, redisClient) => {
+  if(!seedPath) return
   const location = path.join(process.cwd(), seedPath)
   fs.exists(location, (exists) => {
     if (exists) {


### PR DESCRIPTION
If there is no seedPolicies key in serverless.yml then the plugin throws an error. Following code makes setting seedPolicies optional.