### PR TITLE
Refactor IoT SQL encode function

### DIFF
--- a/__tests__/sqlSyntax.test.js
+++ b/__tests__/sqlSyntax.test.js
@@ -1,7 +1,7 @@
 const {parseSelect} = require('../iotSql/parseSql')
 const {applySelect} = require('../iotSql/applySqlSelect')
 const {applyWhereClause} = require('../iotSql/applySqlWhere')
-const {topic, timestamp, clientid, accountid} = require('../iotSql/sqlFunctions')
+const {topic, timestamp, clientid, accountid, encode} = require('../iotSql/sqlFunctions')
 const {sqlParseTestData} = require('../testData')
 
 const log = () => {}
@@ -29,7 +29,9 @@ describe('SQL parser', () => {
         context: {
           topic: (index) => topic(index, parsed.topic),
           clientid: () => clientid(parsed.topic),
-          accountid: () => accountid()
+          timestamp: () => timestamp(),
+          accountid: () => accountid(),
+          encode: (field, encoding) => encode(payload, field, encoding)
         }
       })).toEqual(expected.event)
     })

--- a/iotSql/eval.js
+++ b/iotSql/eval.js
@@ -1,20 +1,15 @@
-const evalInContext = (js, context) => {
-  const {clientid, topic, accountid, timestamp} = context
+const evalInContext = (expr, context) => {
+  let [func, fields] = expr.match(/(\w+)\((.*)\)/).slice(1, 3);
+  fields = fields
+    ? fields.split(",").map((f) => f.trim().replace(/['"]+/g, ""))
+    : [];
+
   try {
-    return eval(js)
+    return context[func](...fields);
   } catch (err) {
-    debugger
-    console.log(`failed to evaluate: ${js}`)
-    throw err
+    debugger;
+    console.log(`failed to evaluate: ${expr}`);
+    throw err;
   }
-}
-
-const encode = (data, encoding) => {
-  if (encoding !== 'base64') {
-    throw new Error('AWS Iot SQL encode() function only supports base64 as an encoding')
-  }
-
-  return data.toString(encoding)
-}
-
-module.exports = evalInContext
+};
+module.exports = evalInContext;

--- a/iotSql/parseSql.js
+++ b/iotSql/parseSql.js
@@ -1,6 +1,6 @@
-const BASE64_PLACEHOLDER = '*b64'
 const SQL_REGEX = /^SELECT (.*) FROM '([^']+)'/
 const SELECT_PART_REGEX = /^(.*?)(?: as (.*))?$/i
+const FIELDS_REGEX = /((\w+[\n\r\s]*\([^)]*\))|([^\n\r\s(,]+))([\n\r\s]+as[\n\r\s]+\w*)?/g
 const WHERE_REGEX = /WHERE (.*)/
 
 const parseSelect = sql => {
@@ -8,12 +8,7 @@ const parseSelect = sql => {
   const [whereClause] = (sql.match(WHERE_REGEX) || []).slice(1)
 
   return {
-    select: select
-    // hack
-      .replace("encode(*, 'base64')", BASE64_PLACEHOLDER)
-      .split(',')
-      .map(s => s.trim())
-      .map(parseSelectPart),
+    select: select.match(FIELDS_REGEX).map(parseSelectPart),
     topic,
     whereClause
   }

--- a/iotSql/sqlFunctions.js
+++ b/iotSql/sqlFunctions.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 module.exports = {
   topic: (index, topicUrl) => (typeof index !== 'undefined') ? topicUrl.split('/')[(index - 1)] : topicUrl,
   clientid: (topicUrl) => {
@@ -8,5 +10,30 @@ module.exports = {
     }
   },
   timestamp: () => (new Date()).getTime(),
-  accountid: () => process.env.AWS_ACCOUNT_ID
+  accountid: () => process.env.AWS_ACCOUNT_ID,
+  encode: (message, field, encoding) => {
+    if (encoding !== "base64") {
+      throw new Error(
+        "AWS Iot SQL encode() function only supports base64 as an encoding"
+      );
+    }
+    if (field === "*") {
+      return Buffer.from(message).toString("base64");
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(message);
+    } catch (e) {
+      console.log(e);
+    }
+
+    const value = _.get(payload, field);
+    if (!value) {
+      throw new Error(
+        `Failed to evaluate encode(${field}, 'base64'): Cannot find ${field} in payload`
+      );
+    }
+    return Buffer.from(value.toString()).toString("base64");
+  },
 }

--- a/ruleHandler.js
+++ b/ruleHandler.js
@@ -9,7 +9,7 @@ const { fillSubstitutionTemplates } = require('./iotSql/substitutionTemplates')
 const mqtt = require('mqtt')
 const mqttMatch = require('mqtt-match')
 const _ = require('lodash')
-const {topic, accountid, clientid, timestamp} = require('./iotSql/sqlFunctions')
+const {topic, accountid, clientid, timestamp, encode} = require('./iotSql/sqlFunctions')
 
 /**
  * Searches serverless.yml for functions configurations.
@@ -172,7 +172,8 @@ module.exports = (slsOptions, slsService, serverless, log) => {
               topic: (index) => topic(index, topicUrl),
               clientid: () => clientid(topicUrl),
               timestamp: () => timestamp(),
-              accountid: () => accountid()
+              accountid: () => accountid(),
+              encode: (field, encoding) => encode(message, field, encoding)
             }
           })
 

--- a/testData.js
+++ b/testData.js
@@ -85,5 +85,39 @@ module.exports.sqlParseTestData = [
         clientid: 'test_client'
       }
     }
+  },
+  {
+    sql: `SELECT encode(*, 'base64') as encodedPayload FROM '$aws/things/sn:123/shadow/update'`,
+    payload: `{"state": {"reported": {"mode": "STAND_BY"}}}`,
+    expected: {
+      parsed: {
+        select: [{ field: "encode(*, 'base64')", alias: "encodedPayload" }],
+        topic: "$aws/things/sn:123/shadow/update",
+      },
+      whereEvaluatesTo: true,
+      event: {
+        encodedPayload:
+          "eyJzdGF0ZSI6IHsicmVwb3J0ZWQiOiB7Im1vZGUiOiAiU1RBTkRfQlkifX19",
+      },
+    },
+  },
+  {
+    sql: `SELECT encode(state.reported.mode, 'base64') as encodedPayload FROM '$aws/things/sn:123/shadow/update'`,
+    payload: `{"state": {"reported": {"mode": "STAND_BY"}}}`,
+    expected: {
+      parsed: {
+        select: [
+          {
+            field: "encode(state.reported.mode, 'base64')",
+            alias: "encodedPayload",
+          },
+        ],
+        topic: "$aws/things/sn:123/shadow/update",
+      },
+      whereEvaluatesTo: true,
+      event: {
+        encodedPayload: "U1RBTkRfQlk=",
+      },
+    },
   }
 ]


### PR DESCRIPTION
Despite of encode(*, 'base64') seemed to be supported (replacing it with the placeholder `*b64`) actually it didn’t work properly.